### PR TITLE
Added app.css (global styling) and app.js to initialize Vue components

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,1 +1,70 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+.font-display {
+    font-family: 'Playfair Display', serif;
+}
+
+.app,
+.app-body {
+    height: auto;
+    min-height: 100%;
+}
+
+.header-icon {
+    color: #74c0fc;
+    font-size: 20px;
+}
+
+.copyright-tag:hover {
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.explore-wrapper {
+    cursor: pointer;
+}
+
+.arrow {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    position: relative;
+    transition: color 0.3s ease;
+}
+
+.arrow::after {
+    content: "→";
+    position: absolute;
+    left: 0;
+    opacity: 0;
+    animation: moveRight 1.2s linear infinite;
+    transition: color 0.3s ease;
+}
+
+.explore-wrapper:hover .arrow::after {
+    font-weight: 900;
+    animation-duration: 0.6s;
+}
+
+@keyframes moveRight {
+    0% {
+        transform: translateX(0);
+        opacity: 0;
+    }
+
+    25% {
+        opacity: 1;
+    }
+
+    70% {
+        transform: translateX(18px);
+        opacity: 1;
+    }
+
+    100% {
+        transform: translateX(30px);
+        opacity: 0;
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,9 +1,41 @@
 import '../css/app.css';
 import './bootstrap';
+import './alpine/app-state';
+
 import { createApp } from 'vue';
-import ExampleComponent from './Components/ExampleComponent.vue';
 
-const app = createApp({});
-app.component('example-component', ExampleComponent);
-app.mount('#app');
+import FeaturedArticleCatalog from './Components/Articles/Catalog/FeaturedArticleCatalog.vue';
+import CompleteArticleCatalog from './Components/Articles/Catalog/CompleteArticleCatalog.vue';
+import ArticleComposer from './Components/Articles/Composer/ArticleComposer.vue';
+import CommentSection from './Components/Articles/Comments/CommentSection.vue';
+import CommentCard from './Components/Articles/Comments/CommentCard.vue';
 
+const featuredCatalogElement = document.querySelector('#world-of-articles');
+const completeCatalogElement = document.querySelector('#complete-articles');
+const articleComposerElement = document.querySelector('#article-composer');
+const commentSectionElement = document.querySelector('#comment-section');
+
+if (featuredCatalogElement) {
+    const featuredCatalog = createApp({});
+    featuredCatalog.component('featured-article-catalog', FeaturedArticleCatalog);
+    featuredCatalog.mount('#world-of-articles');
+}
+
+if (completeCatalogElement) {
+    const completeCatalog = createApp({});
+    completeCatalog.component('complete-article-catalog', CompleteArticleCatalog);
+    completeCatalog.mount('#complete-articles');
+}
+
+if (articleComposerElement) {
+    const articleComposer = createApp({});
+    articleComposer.component('article-composer', ArticleComposer);
+    articleComposer.mount('#article-composer');
+}
+
+if (commentSectionElement) {
+    const commentSection = createApp({});
+    commentSection.component('comment-section', CommentSection);
+    commentSection.component('comment-card', CommentCard);
+    commentSection.mount('#comment-section');
+}


### PR DESCRIPTION
**Resolves**  

-   #21 

### Description

This PR introduces two core asset files — app.css and app.js — which will serve as the foundation for front-end styling and Vue component setup within the project.

### Key Changes

- Added app.css to manage global/overall styling
- Added app.js to initialize Vue and register components
- Prepared the structure for scalable and maintainable UI development

### Why This Matters
These files establish the base layer for styling and front-end scripting. With a globally accessible CSS file and a unified Vue entry point, future UI work will be more consistent, modular, and easier to extend.

### Future Enhancements / Next Steps
- Add component discovery or auto-registration
- Structure styles using utility classes, variables, or partials
- Integrate further Vue components and UI features